### PR TITLE
fix ESP32 crash when using SoftwareSerial as transmitter only (RxPin=-1)

### DIFF
--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -90,10 +90,10 @@ bool SoftwareSerial::isValidGPIOpin(int8_t pin) {
     // Pinout    https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/_images/esp32-c3-devkitm-1-v1-pinout.jpg
     return (pin >= 0 && pin <= 1) || (pin >= 3 && pin <= 7) || (pin >= 18 && pin <= 21);
 #else 
-    return true;
+    return pin >= 0;
 #endif
 #else
-    return true;
+    return pin >= 0;
 #endif
 }
 


### PR DESCRIPTION
the ESP32 implementation crashes when calling begin(..) having rxPin=-1

Bug only occurs on older build environments, where some preprocessor variables like CONFIG_IDF_TARGET_ESP32S2 are not defined.

In this case digitalPinToInterrupt(m_rxPin) fails in method enableRx()



